### PR TITLE
Es module interop

### DIFF
--- a/sources/code/global/modules/package.ts
+++ b/sources/code/global/modules/package.ts
@@ -5,7 +5,7 @@
 import { resolve } from "path";
 import { parse } from "semver";
 import { readFileSync, existsSync } from "fs";
-import * as spdxParse from "spdx-expression-parse";
+import spdxParse from "spdx-expression-parse";
 
 interface PersonObject {
 	name: string,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
+        /* Fix CommonJS/ES6 interoperability issues */
+        "esModuleInterop": true,
         /* Whenever incremental compilation is enabled */
         "incremental": true,
         /* File containing saved information about incremental compilation */


### PR DESCRIPTION
Fixes support for ES Module interoperability. Made this patch on my own fork to ensure best practices (namespaced imports shouldn't be callable functions, this violates spec), sending upstream so nothing breaks for me later if another bad import sneaks in.

See https://www.typescriptlang.org/tsconfig#esModuleInterop for more information.