### PR TITLE
Fix typo in Contributing.md

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -45,5 +45,5 @@ You can also help to maintain this project by:
   - reviewing the WebCord's source code or pull requests and suggesting the
     changes.
 
-[`Build.md`]: Build.med
+[`Build.md`]: Build.md
 [`Flags.md`]: Flags.md


### PR DESCRIPTION
Was reading the contributing guide and saw that `Build` was linked to `Build.med` and not `Build.md`