### PR TITLE
Add keybind socket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "dompurify": "^2.3.6",
         "electron-fetch": "^1.7.3",
         "highlight.js": "^11.4.0",
+        "keycode": "2.2.1",
         "marked": "^4.0.12",
         "semver": "^7.3.5",
         "source-map-support": "^0.5.21",
@@ -5861,6 +5862,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/keycode": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
+      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg=="
     },
     "node_modules/keyv": {
       "version": "4.5.0",
@@ -13060,6 +13066,11 @@
       "resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
       "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
       "dev": true
+    },
+    "keycode": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
+      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg=="
     },
     "keyv": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "dompurify": "^2.3.6",
     "electron-fetch": "^1.7.3",
     "highlight.js": "^11.4.0",
+    "keycode": "2.2.1",
     "marked": "^4.0.12",
     "semver": "^7.3.5",
     "source-map-support": "^0.5.21",

--- a/sources/code/main/modules/keybind-socket.ts
+++ b/sources/code/main/modules/keybind-socket.ts
@@ -15,6 +15,11 @@ interface KeybindState {
 }
 
 export default function bindKeybindSocket(window: Electron.BrowserWindow) {
+  if (!process.argv.includes("--ozone-platform=wayland")) {
+    console.error("[Keybinds] Not running under Wayland. Will not bind socket.");
+    return;
+  }
+
   const runtimeDirectory = process.env["XDG_RUNTIME_DIR"] ?? `/run/user/${os.userInfo().uid}`;
   const socketPath = `${runtimeDirectory}/webcord-keybinds.sock`;
   const socket = net.createServer((connection) => {

--- a/sources/code/main/modules/keybind-socket.ts
+++ b/sources/code/main/modules/keybind-socket.ts
@@ -2,6 +2,7 @@ import net from "net";
 import fs from "fs";
 import keycode from "keycode";
 import { app, ipcMain } from "electron/main";
+import os from "os";
 
 interface KeybindState {
   _state?: Record<string, {
@@ -14,12 +15,8 @@ interface KeybindState {
 }
 
 export default function bindKeybindSocket(window: Electron.BrowserWindow) {
-  if (!process.env["XDG_RUNTIME_DIR"]) {
-    console.error("[Keybinds] $XDG_RUNTIME_DIR is not defined. Will not bind socket.");
-    return;
-  }
-
-  const socketPath = `${process.env["XDG_RUNTIME_DIR"]}/webcord-keybinds.sock`;
+  const runtimeDirectory = process.env["XDG_RUNTIME_DIR"] ?? `/run/user/${os.userInfo().uid}`;
+  const socketPath = `${runtimeDirectory}/webcord-keybinds.sock`;
   const socket = net.createServer((connection) => {
     console.log("[Keybinds] Received socket connection.");
 

--- a/sources/code/main/modules/keybind-socket.ts
+++ b/sources/code/main/modules/keybind-socket.ts
@@ -1,0 +1,81 @@
+import net from "net";
+import fs from "fs";
+import keycode from "keycode";
+import { app, ipcMain } from "electron/main";
+
+interface KeybindState {
+  _state?: Record<string, {
+    id: string;
+    action: string;
+    shortcut: [0, number, 4][];
+    managed: boolean;
+    context: string;
+  }>;
+}
+
+export default function bindKeybindSocket(window: Electron.BrowserWindow) {
+  if (!process.env["XDG_RUNTIME_DIR"]) {
+    console.error("[Keybinds] $XDG_RUNTIME_DIR is not defined. Will not bind socket.");
+    return;
+  }
+
+  const socketPath = `${process.env["XDG_RUNTIME_DIR"]}/webcord-keybinds.sock`;
+  const socket = net.createServer((connection) => {
+    console.log("[Keybinds] Received socket connection.");
+
+    let payload: Buffer | null = null;
+
+    connection.on("data", (dataPart: Buffer) => {
+      console.debug("[Keybinds] Data received.", dataPart);
+      payload = Buffer.concat(payload ? [payload, dataPart] : [dataPart]);
+    });
+    connection.on("end", () => {
+      console.log("[Keybinds] Connection ended.");
+
+      if (!payload) {
+        console.error("[Keybinds] No data provided.");
+        return;
+      }
+      if (payload.indexOf(Buffer.from([0x99, 0x00]), -3) === -1) {
+        console.error("[Keybinds] Invalid payload provided.");
+        return;
+      }
+
+      const action = payload.subarray(0, payload.indexOf(0x00)).toString();
+      const remaining = payload.subarray(payload.indexOf(0x00) + 1);
+      const state = remaining[0];
+
+      const handler = (_event: Electron.IpcMainEvent, value: KeybindState) => {
+        ipcMain.removeListener("keybinds-value", handler);
+        if (!value._state) {
+          console.error("[Keybinds] Could not get keybinds from Discord.");
+          return;
+        }
+        const keybinds = Object.values(value._state);
+        const handled = keybinds.some((keybind) => {
+          const accelerator = keybind.shortcut.map((shortcut) => keycode(shortcut[1])).join("+");
+
+          if (keybind.action === action) {
+            window.webContents.sendInputEvent({
+              type: state === 0x01 ? "keyDown" : "keyUp",
+              keyCode: accelerator,
+            });
+            return true;
+          }
+
+          return false;
+        });
+
+        if (!handled) {
+          console.error("[Keybinds] Undefined keybind. Make sure that you have defined a key for this action.");
+        }
+      };
+      ipcMain.on("keybinds-value", handler);
+      window.webContents.send("pull-keybinds");
+    });
+
+    connection.end();
+  });
+  socket.listen(socketPath, () => console.log(`[Keybinds] Socket opened at ${socketPath}.`));
+  app.on("quit", () => { fs.unlinkSync(socketPath); });
+}

--- a/sources/code/main/modules/keybind-socket.ts
+++ b/sources/code/main/modules/keybind-socket.ts
@@ -15,6 +15,11 @@ interface KeybindState {
 }
 
 export default function bindKeybindSocket(window: Electron.BrowserWindow) {
+  if (process.platform === "win32" || process.platform === "darwin") {
+    console.error("[Keybinds] Not running under non-macOS UNIX. Will not bind socket.");
+    return;
+  }
+
   if (!process.argv.includes("--ozone-platform=wayland")) {
     console.error("[Keybinds] Not running under Wayland. Will not bind socket.");
     return;

--- a/sources/code/main/windows/main.ts
+++ b/sources/code/main/windows/main.ts
@@ -22,6 +22,7 @@ import { getWebCordCSP } from "../modules/csp";
 import l10n from "../../common/modules/l10n";
 import { loadChromiumExtensions, styles } from "../modules/extensions";
 import { commonCatches } from "../modules/error";
+import bindKeybindSocket from "../modules/keybind-socket";
 
 import type { PartialRecursive } from "../../common/global";
 import { nativeImage } from "electron/common";
@@ -532,5 +533,8 @@ export default function createMainWindow(flags:MainWindowFlags): BrowserWindow {
       win.webContents.paste();
     });
   });
+
+  // Bind socket server for keybinds.
+  bindKeybindSocket(win);
   return win;
 }

--- a/sources/code/renderer/preload/main.ts
+++ b/sources/code/renderer/preload/main.ts
@@ -37,6 +37,18 @@ if (window.location.protocol === "file:") {
   window.addEventListener("load", () => window.localStorage.setItem("hideNag", "true"));
 
   /*
+   * Pull user-defined keybinds from localStorage.
+   */
+  ipc.on("pull-keybinds", (event) => {
+    if (typeof window.localStorage["keybinds"] === "string") {
+      event.sender.send(
+        "keybinds-value",
+        JSON.parse(window.localStorage["keybinds"]),
+      );
+    }
+  });
+
+  /*
   * Workaround for clipboard content.
   */
   {


### PR DESCRIPTION
Because Wayland forbids non-root processes from listening to system-wide keypresses, Discord and WebCord are unable to listen for keybinds when the window doesn't have focus. This pull request adds a socket server that allows for sending a payload to forward keybinds to WebCord, so that you may use a privileged process to handle shortcuts like sway or swhkd. An example of activating the push-to-talk key is:

`echo -e 'PUSH_TO_TALK\x00\x01\x99\x00' | nc -U $XDG_RUNTIME_DIR/webcord-keybinds.sock`

The payload begins with one of the keybind actions that Discord supports, which is terminated with a null (\x00) byte. The byte that follows is a boolean value - a true value (\x01) indicates a keyDown event, and a false value (\x00) indicates a keyUp event. Note that keybinds that aren't toggle-based, like PUSH_TO_TALK, generally only respond to keyUp events.

This feature works by pulling the user's keybinds, finding the key set for a particular command, and then simulating a keypress through `setInputEvent` on the main Electron window. While the implementation sounds weird, it's the best way to go about it without injecting code into the webpage to interface directly with the keybind handlers - something that I understand you want to avoid with WebCord for user safety reasons.

An extra package was added called `keycode` to translate the JavaScript keycodes into accelerators, that are then passed to setInputEvent. I've pinned this package to the latest version just in case - if you'd like this unpinned or removed entirely then let me know.

While the changes in this pull request allow for sending key events for any keybindings that have been set, of course there's no actual mechanism to set any of these keybinds apart from PUSH_TO_TALK, because Discord disables the keybinding interface on the web version. I was thinking of potentially adding an option to configure keybindings via the socket interface, but opted against it for this pull request. At least now, any future global keybinds interface can be made to work for both Wayland and X11.

If there's any issues or concerns with the socket payload format, or I missed something else in the implementation, feel free to suggest changes and I can sort.