### PR TITLE
Move "Toggle" to top of tray menu

### DIFF
--- a/sources/code/main/modules/menu.ts
+++ b/sources/code/main/modules/menu.ts
@@ -108,6 +108,11 @@ export function tray(parent: Electron.BrowserWindow): Electron.Tray {
   }
   const contextMenu = Menu.buildFromTemplate([
     {
+      label: strings.tray.toggle,
+      click: toogleVisibility
+    },
+    { type: "separator" },
+    {
       label: strings.windows.about,
       click: () => showAboutPanel(parent)
     },
@@ -120,10 +125,6 @@ export function tray(parent: Electron.BrowserWindow): Electron.Tray {
       click: () => void createGithubIssue().catch(commonCatches.throw)
     },
     { type: "separator" },
-    {
-      label: strings.tray.toggle,
-      click: toogleVisibility
-    },
     {
       label: strings.tray.quit,
       click: () => app.quit()


### PR DESCRIPTION
Makes it easier to click ([Fitt's Law](https://en.wikipedia.org/wiki/Fitts%27s_law#Implications_for_UI_design) and all that), and I think it's what the official Electron client does.