### PR TITLE
Disable IdleDetector API by default, add config checkbox

### DIFF
--- a/sources/code/main/modules/config.ts
+++ b/sources/code/main/modules/config.ts
@@ -107,7 +107,8 @@ const defaultAppConfig = {
         gpu: false
       },
       webApi: {
-        webGl: true
+        webGl: true,
+        idleDetector: false
       },
       unix: {
         autoscroll: false

--- a/sources/code/main/windows/main.ts
+++ b/sources/code/main/windows/main.ts
@@ -64,7 +64,8 @@ export default function createMainWindow(flags:MainWindowFlags): BrowserWindow {
       enableWebSQL: false,
       webgl: configData.get().settings.advanced.webApi.webGl,
       safeDialogs: true, // prevents dialog spam by the website
-      autoplayPolicy: "no-user-gesture-required"
+      autoplayPolicy: "no-user-gesture-required",
+      disableBlinkFeatures: configData.get().settings.advanced.webApi.idleDetector ? "" : "IdleDetection"
     },
     ...(process.platform !== "win32" ? {icon: appInfo.icons.app} : {}),
   });

--- a/sources/translations/en/settings.json
+++ b/sources/translations/en/settings.json
@@ -93,7 +93,8 @@
             "name": "Access to JavaScript APIs",
             "description": "Controls which API should be permitted in unpriviledged (DOM) scripts.",
             "labels": {
-                "webGl": "Enable WebGL support."
+                "webGl": "Enable WebGL support.",
+                "idleDetector": "Allow user activity detection (IdleDetector API)."
             }
         },
         "unix": {


### PR DESCRIPTION
Greetings :)

From my and other anecdotal accounts it looks like Discord now makes people "green" way more eagerly than it did before, on at least Linux and Windows, both the official app and WebCord. At least on KDE Plasma, various apps will wrongly enforce "presentation mode", and therefore Discord will always show the user as "green". As someone who uses Discord for work this has been extremely annoying, as this also disables phone notifications completely.

I am guessing this is related to the [new non-standard](https://developer.mozilla.org/en-US/docs/Web/API/IdleDetector) `IdleDetector` API Chrome (and therefore Electron) added recently. It can be disabled via a Blink flag to BrowserWindow, and after doing that the "online" behavior seems to have returned to sanity in the last few days. 

Therefore I made it a checkbox and also made it off by default. Discord still correctly turns from "away" to "active" when there is actual activity in the window. I didn't have time to investigate whether it detects any system-wide activity, like mouse movement, in any other way.

Only tested on ArchLinux / KDE Plasma / Discord for now, but the change is small and only disables a relatively new feature.