### PR TITLE
Setting: Close tray icon on quit

### DIFF
--- a/sources/code/main/modules/config.ts
+++ b/sources/code/main/modules/config.ts
@@ -63,7 +63,8 @@ const defaultAppConfig = {
         hide: false
       },
       tray: {
-        disable: false
+        disable: false,
+        quitOnClose: false
       },
       taskbar: {
         flash: true

--- a/sources/code/main/modules/menu.ts
+++ b/sources/code/main/modules/menu.ts
@@ -148,11 +148,15 @@ export function tray(parent: Electron.BrowserWindow): Electron.Tray {
     app.once("before-quit", () => willQuit = true);
     parent.on("close", (event) => {
       if (!willQuit) {
-        event.preventDefault();
-        parent.hide();
+        if(!appConfig.get().settings.general.tray.quitOnClose) {
+          event.preventDefault();
+          parent.hide();
+        }
       }
     });
   }
+
+
   return tray;
 }
 

--- a/sources/translations/en/settings.json
+++ b/sources/translations/en/settings.json
@@ -13,7 +13,8 @@
             "name": "Tray",
             "description": "Changes the visibility of the icon in the system tray.",
             "labels": {
-                "disable": "Disable hiding window to the system tray functionality."
+                "disable": "Disable hiding window to the system tray functionality.",
+                "quitOnClose": "Close tray when closing the window."
             }
         },
         "taskbar": {


### PR DESCRIPTION
Implements this feature request: #263

Adds a new setting under "tray" category

![image](https://user-images.githubusercontent.com/25406449/194674566-873d93a4-7e9b-4dfa-8471-20f02cc85772.png)

Turning this setting on will make the tray close when you close the window.
Toggling the window with the tray icon works the same.

Possible changes:
- Needs translations for the new setting.
- Wording can be changed if someone comes up with a better way to describe this feature.
- Only show this setting if the tray icon is enabled.