### PR TITLE
Fix Spotify playlist embeds

### DIFF
--- a/sources/code/main/modules/csp.ts
+++ b/sources/code/main/modules/csp.ts
@@ -138,9 +138,9 @@ const csp: {base:CSP}&cspTP<CSP> = {
   }),
   soundcloud: new CSP({ "frame-src": "https://w.soundcloud.com/player/" }),
   spotify: new CSP({
-    "script-src": "https://open.spotifycdn.com/cdn/build/embed/",
+    "script-src": "https://open.spotifycdn.com/cdn/build/embed/ https://open.spotifycdn.com/cdn/build/embed-legacy/",
     "img-src": "https://open.spotifycdn.com/cdn/images/ https://i.scdn.co/image/",
-    "style-src": "https://open.spotifycdn.com/cdn/build/embed/",
+    "style-src": "https://open.spotifycdn.com/cdn/build/embed/ https://open.spotifycdn.com/cdn/build/embed-legacy/",
     "connect-src": "wss://dealer.spotify.com https://api.spotify.com https://open.spotifycdn.com/cdn/generated-locales/embed/",
     "frame-src": "https://open.spotify.com/",
     "media-src": "https://p.scdn.co/mp3-preview/"


### PR DESCRIPTION
Since the new Spotify embeds were introduced, playlist embeds stopped working as they use a different URL that is absent from the CSP.