### PR TITLE
Update main.ts fix typo verbose short

### DIFF
--- a/sources/code/common/main.ts
+++ b/sources/code/common/main.ts
@@ -49,7 +49,7 @@ const argvConfig = Object.freeze({
     "help": { type: "boolean", short: "h" },
     /** An alias to `help` command-line option. */
     "info": { type: "boolean", short: "?" },
-    "version": { type: "boolean", short: "v" },
+    "version": { type: "boolean", short: "V" },
     "start-minimized": { type: "boolean", short: "m" },
     "export-l10n": { type: "string" },
     "verbose": { type: "boolean", short: "v" },


### PR DESCRIPTION
The typo prevented people from doing `./webcord -v` to get verbose info using the short name. Instead it gave the version -- even though the Options print shown it was `--verbose   -v`; `--version   -V`