### PR TITLE
Switch to`setDisplayMediaHandler` API.

### DIFF
--- a/sources/code/common/global.ts
+++ b/sources/code/common/global.ts
@@ -39,6 +39,11 @@ export const enum GPUVendors {
   Intel = 0x8086
 }
 
+export const enum ElectronAudioStream {
+  All = "loopback",
+  Filtered = "loopbackWithMute"
+}
+
 /**
  * Allowed protocol list.
  * 
@@ -220,3 +225,22 @@ export function typeMerge<T extends object>(source: T, config: TypeMergeConfig, 
   return (objects as T[])
     .reduce((prev, cur:unknown) => deepMerge(prev, cur), source);
 }
+
+interface ElectronDisplayMediaRequest extends Electron.DisplayMediaRequestHandlerHandlerRequest {
+  frame: Electron.WebFrameMain;
+  securityOrigin: string;
+  videoRequested: boolean;
+  audioRequested: boolean;
+  userGesture: boolean;
+}
+
+type ElectronVideoStream = { name: string; id: string } & Partial<Electron.DesktopCapturerSource>;
+
+interface ElectronStreams {
+  audio: ElectronAudioStream | Electron.WebFrameMain;
+  video: ElectronVideoStream | Electron.WebFrameMain;
+}
+
+export type SessionOverride = Electron.Session & {
+  setDisplayMediaRequestHandler?:(handler:((request:ElectronDisplayMediaRequest, callback: (ElectronStreams|null)) => void)|null) => void;
+};

--- a/sources/code/renderer/modules/capturer.ts
+++ b/sources/code/renderer/modules/capturer.ts
@@ -1,4 +1,4 @@
-import { ipcRenderer as ipc } from "electron/renderer";
+/*import { ipcRenderer as ipc } from "electron/renderer";
 
 interface EMediaStreamConstraints extends MediaStreamConstraints {
   audio?: boolean | EMediaTrackConstraints;
@@ -49,4 +49,4 @@ export default function desktopCapturerPicker(api:string): Promise<EMediaStreamC
       }
     }).catch((reason:unknown) => reject(reason));
   });
-}
+}*/

--- a/sources/code/renderer/preload/capturer.ts
+++ b/sources/code/renderer/preload/capturer.ts
@@ -100,18 +100,9 @@ window.addEventListener("DOMContentLoaded", () => {
                 throw new Error('Source with id: "' + (id ?? "[null]") + '" does not exist!');
               }
               ipc.send("closeCapturerView", {
-                audio: audioSupport && (audioButton?.checked ?? false) ? {
-                  mandatory: {
-                    chromeMediaSource: "desktop"
-                  }
-                } : false,
-                video: {
-                  mandatory: {
-                    chromeMediaSource: "desktop",
-                    chromeMediaSourceId: source.id
-                  }
-                }
-              });
+                ...(audioSupport && (audioButton?.checked ?? false) ? {audio: "loopbackWithMute"} : {}),
+                video: { id: source.id, name: source.name }
+              } satisfies Electron.Streams);
             })
           );
           document.getElementById("capturer-close")


### PR DESCRIPTION
Since Electron 22 there's a new API to specifically handle requests send by `getDisplayMedia`, which sounds to be more appropiate that overwritting built-in functions with multiple scripts under-the-hood. This API also fixes the issue #186 for Windows (Chromium doesn't support other platforms so fixing this is out of the scope for this issue).

This is currently at work-in-progress, the API itself seems to be quite immature to be used and there's both no fallback code for older Electron versions nor Electron has adopted it to all currently supported versions.