### PR TITLE
Initial implementation of global shortcuts for mute and deafen

### DIFF
--- a/sources/code/common/main.ts
+++ b/sources/code/common/main.ts
@@ -42,6 +42,7 @@ import { getRecommendedGPUFlags, getRedommendedOSFlags } from "../main/modules/o
 import { styles } from "../main/modules/extensions";
 import { parseArgs, ParseArgsConfig, stripVTControlCharacters, debug } from "util";
 import { parseArgs as parseArgsPolyfill } from "@pkgjs/parseargs";
+import { registerShortcuts } from "../main/modules/shortcuts";
 
 const argvConfig = Object.freeze(({
   options: Object.freeze({
@@ -368,7 +369,7 @@ function main(): void {
     }, 30/*min*/*60000);
     checkVersion(updateInterval).catch(commonCatches.print);
     const mainWindow = createMainWindow({startHidden, screenShareAudio});
-    
+    registerShortcuts(mainWindow);
     // WebSocket server
     import("../main/modules/socket")
       .then(socket => socket.default())

--- a/sources/code/main/modules/shortcuts.ts
+++ b/sources/code/main/modules/shortcuts.ts
@@ -1,0 +1,16 @@
+import { BrowserWindow, globalShortcut } from "electron/main";
+import { commonCatches } from "./error";
+
+export function registerShortcuts(window: BrowserWindow) {
+  globalShortcut.register("Insert", () => {
+    window.webContents.executeJavaScript(
+      "document.querySelector('button[aria-label=\"Mute\"').click()"
+    ).catch(commonCatches.print);
+  });
+
+  globalShortcut.register("F1", () => {
+    window.webContents.executeJavaScript(
+      "document.querySelector('button[aria-label=\"Deafen\"').click()"
+    ).catch(commonCatches.print);
+  });
+}


### PR DESCRIPTION
Hi, this is just an initial test implementation for adding global shortcuts for toggling mute and deafen.
Is this something you'd be interested in merging? I don't know a lot about electron, is `window.webContents.executeJavaScript` safe to use?

I'll add settings like setting your own shortcut later