### PR TITLE
Fix broken ⌘A shortcut (Select All) on macOS

### DIFF
--- a/sources/code/main/modules/menu.ts
+++ b/sources/code/main/modules/menu.ts
@@ -225,7 +225,9 @@ export function bar(repoLink: string, parent: Electron.BrowserWindow): Electron.
       { type: "separator" },
       { label: strings.context.cut, role: "cut" },
       { label: strings.context.copy, role: "copy" },
-      { label: strings.context.paste, role: "paste" }
+      { label: strings.context.paste, role: "paste" },
+      { type: "separator" },
+      { role: "selectAll" },
     ]},
     // View
     {


### PR DESCRIPTION
This adds the Select All button to the Edit menu.

- Electron's menu API requires "Select All" to be present in the Edit menu, in order for the ⌘A shortcut to function
- This fixes issue #319