### PR TITLE
Update electron to v23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@types/ws": "^8.5.1",
         "@typescript-eslint/eslint-plugin": "^5.41.0",
         "@typescript-eslint/parser": "^5.41.0",
-        "electron": ">=17.0.0 <23.0.0",
+        "electron": ">=23.0.0",
         "eslint": "latest",
         "eslint-import-resolver-typescript": "latest",
         "eslint-plugin-import": "latest",
@@ -72,9 +72,9 @@
       "optional": true
     },
     "node_modules/@electron-forge/cli": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-6.0.4.tgz",
-      "integrity": "sha512-iyQyh0g/cSWVQs30wsAqmTmqgV8E/i9Cy/CsHwHxQlsHHcq8N61k1JlB2dpEV1Hy9Lxafql5TE3/6uI7939IEg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-6.0.5.tgz",
+      "integrity": "sha512-3xD4XKyV634cQCR8HobpVnb4LqVdTHDs+KwsU9zgjaBIJMBapCS3ZzpXYbxzPekTaVwu39ojMUg990JVYBhs2A==",
       "dev": true,
       "funding": [
         {
@@ -87,8 +87,8 @@
         }
       ],
       "dependencies": {
-        "@electron-forge/core": "^6.0.4",
-        "@electron-forge/shared-types": "^6.0.4",
+        "@electron-forge/core": "6.0.5",
+        "@electron-forge/shared-types": "6.0.5",
         "@electron/get": "^2.0.0",
         "chalk": "^4.0.0",
         "commander": "^4.1.1",
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@electron-forge/core": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-6.0.4.tgz",
-      "integrity": "sha512-l3OiXB/9ebtZZtcQAbofaTmivQUqUVv8TKoxQ8GJbH48Eyk//mphbo7hDC5kb5Tyd0UedMOM9MxJrYjnd6jRnA==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-6.0.5.tgz",
+      "integrity": "sha512-lMtm3x2ZFEBOU7/JTIo2oI5dXm2hKqpdc4opHA7iOxja5YYDDvnqKt+tACJSCdnCOxYLS+0OSoaz/DJ8SNyStw==",
       "dev": true,
       "funding": [
         {
@@ -122,14 +122,14 @@
         }
       ],
       "dependencies": {
-        "@electron-forge/core-utils": "^6.0.4",
-        "@electron-forge/maker-base": "^6.0.4",
-        "@electron-forge/plugin-base": "^6.0.4",
-        "@electron-forge/publisher-base": "^6.0.4",
-        "@electron-forge/shared-types": "^6.0.4",
-        "@electron-forge/template-base": "^6.0.4",
-        "@electron-forge/template-webpack": "^6.0.4",
-        "@electron-forge/template-webpack-typescript": "^6.0.4",
+        "@electron-forge/core-utils": "6.0.5",
+        "@electron-forge/maker-base": "6.0.5",
+        "@electron-forge/plugin-base": "6.0.5",
+        "@electron-forge/publisher-base": "6.0.5",
+        "@electron-forge/shared-types": "6.0.5",
+        "@electron-forge/template-base": "6.0.5",
+        "@electron-forge/template-webpack": "6.0.5",
+        "@electron-forge/template-webpack-typescript": "6.0.5",
         "@electron/get": "^2.0.0",
         "@electron/rebuild": "^3.2.10",
         "@malept/cross-spawn-promise": "^2.0.0",
@@ -160,12 +160,12 @@
       }
     },
     "node_modules/@electron-forge/core-utils": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-6.0.4.tgz",
-      "integrity": "sha512-nOCjmm8Qr/bYkVNfEiXSk/LKjtv6iBrKcyhKIanNM3n7MJRuTH0ksvuajFBqg+V+EHplMb7y6acDvI+TTRDUxg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-6.0.5.tgz",
+      "integrity": "sha512-KCxTQOGRGITUwdxMu63xFn4SkuBE6Fvn188MjZHyztAHimiKBWdNGBrBHgjR2WyYTziT8y6JXcAntAW5d+jYHQ==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "^6.0.4",
+        "@electron-forge/shared-types": "6.0.5",
         "@electron/rebuild": "^3.2.10",
         "@malept/cross-spawn-promise": "^2.0.0",
         "chalk": "^4.0.0",
@@ -181,12 +181,12 @@
       }
     },
     "node_modules/@electron-forge/maker-base": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-6.0.4.tgz",
-      "integrity": "sha512-qJJ2oPFlyt6u/H67WLfZL0JclSpFj4VwxPfwxqNL/HcwXULJcOeat7oqJLY9UKBE4U2j+++xbA3LSoPAErroIg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-6.0.5.tgz",
+      "integrity": "sha512-m3xS/Gd2XlYUjXO4o8bxZEcwN9AulMDjuIzq68FRH5VB1vuESJKtVZjSa331IjaA+0aRXbSCa108FLy8g5Qlaw==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "^6.0.4",
+        "@electron-forge/shared-types": "6.0.5",
         "fs-extra": "^10.0.0",
         "which": "^2.0.2"
       },
@@ -195,13 +195,13 @@
       }
     },
     "node_modules/@electron-forge/maker-deb": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-6.0.4.tgz",
-      "integrity": "sha512-kBqRiPqAInPqBEZD1iRYiF2yb7Mhcdlrn80kCtTwTF8oAA6d081g6mcrMt12sf5GBGF8IXKzm6JqbqelpYbKww==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-6.0.5.tgz",
+      "integrity": "sha512-uaDxBeLhJcrySnPGPEZbGwJG7qeiBE05+rdkPpsfHzsTBYca1abQ2Ll66R5EmOrosIZv60OUt1eGyxOrWlo1+w==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/maker-base": "^6.0.4",
-        "@electron-forge/shared-types": "^6.0.4"
+        "@electron-forge/maker-base": "6.0.5",
+        "@electron-forge/shared-types": "6.0.5"
       },
       "engines": {
         "node": ">= 14.17.5"
@@ -211,13 +211,13 @@
       }
     },
     "node_modules/@electron-forge/maker-dmg": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-6.0.4.tgz",
-      "integrity": "sha512-03Q6dVpZu7HdvBFtcZVoCSN0lA3Iqi3H/JjR82G0cWINwgwAKzBlGIcZmkfU+fdBAiO4Z6tUfaYrDDtBhpn1sQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-6.0.5.tgz",
+      "integrity": "sha512-FZzP7iNucLPHA7Fcp2O+nw5qQcDkQyewdMjpYLoMBkCrHTRghVq63q2A8RN0JvyOkSmRIxaw3cc96w3eV8O3pw==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/maker-base": "^6.0.4",
-        "@electron-forge/shared-types": "^6.0.4",
+        "@electron-forge/maker-base": "6.0.5",
+        "@electron-forge/shared-types": "6.0.5",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -228,13 +228,13 @@
       }
     },
     "node_modules/@electron-forge/maker-flatpak": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-flatpak/-/maker-flatpak-6.0.4.tgz",
-      "integrity": "sha512-1X0JJJbSXq1FiAzmIF0Z0EWsi5AnlYHYVMEmAY8CCdnvwJ+OWwfOvBx2yRWPAiIJPzK/bkG14jvsgHSVRnEWcA==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-flatpak/-/maker-flatpak-6.0.5.tgz",
+      "integrity": "sha512-+/95Dbfh1RBGzjtPOLrdkvnlw4HnzP0rv+irUa2Owg3XRJbbIGMyfoODlO3mufHT6qhrIwHk+d2U3UKgE/Xwxg==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/maker-base": "^6.0.4",
-        "@electron-forge/shared-types": "^6.0.4",
+        "@electron-forge/maker-base": "6.0.5",
+        "@electron-forge/shared-types": "6.0.5",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -245,13 +245,13 @@
       }
     },
     "node_modules/@electron-forge/maker-rpm": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-rpm/-/maker-rpm-6.0.4.tgz",
-      "integrity": "sha512-uNLm6zpK8OgXl2Eq9/uaQyUBKEJhlzJf4zu0DtpPqp5qeu1EObDor0/5OH6MTEmjpGSZ616tdvVN+kwqjNeNHg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-rpm/-/maker-rpm-6.0.5.tgz",
+      "integrity": "sha512-qwrTMo8kBf6fsPi6S22qCvD5F2OeJ8F4c0vuHi9YCUoPVjU3wBsvxi+lJclkdTqgzRWidfZ1vsbltcOSZb+2fw==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/maker-base": "^6.0.4",
-        "@electron-forge/shared-types": "^6.0.4"
+        "@electron-forge/maker-base": "6.0.5",
+        "@electron-forge/shared-types": "6.0.5"
       },
       "engines": {
         "node": ">= 14.17.5"
@@ -261,13 +261,13 @@
       }
     },
     "node_modules/@electron-forge/maker-snap": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-snap/-/maker-snap-6.0.4.tgz",
-      "integrity": "sha512-lvEnYpr1QWwI9Xxzhr/Isr33F7hBq4UDtR+SNw9GZAtc2063fWAVSXNfCK+HcBMIK8W4cO7ndIydGtxixR21hA==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-snap/-/maker-snap-6.0.5.tgz",
+      "integrity": "sha512-caduuUTViLOcbFU9T5OsmdtuujNMQ6VvGD6iYL8CBrnnRZZKi5sQVHfQZRQNlssvx73j9QS0OGynN1Nzlz0uAQ==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/maker-base": "^6.0.4",
-        "@electron-forge/shared-types": "^6.0.4"
+        "@electron-forge/maker-base": "6.0.5",
+        "@electron-forge/shared-types": "6.0.5"
       },
       "engines": {
         "node": ">= 14.17.5"
@@ -277,13 +277,13 @@
       }
     },
     "node_modules/@electron-forge/maker-squirrel": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-6.0.4.tgz",
-      "integrity": "sha512-1bZ5RgSex5Y45HSuOqjki2oHIq/CquVPP5sLYhObd2p2ABj4ZzyqErNFK1eerDIjoesici3KKCASqBpKf2N90Q==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-6.0.5.tgz",
+      "integrity": "sha512-moP4OIytJlqxx3J7UCWrOv04tepjQIzK9RdzK4m9jfjPAxZtRObesFGXr/jLO18NHXk7fDcbYLf3sTIfaPU6jg==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/maker-base": "^6.0.4",
-        "@electron-forge/shared-types": "^6.0.4",
+        "@electron-forge/maker-base": "6.0.5",
+        "@electron-forge/shared-types": "6.0.5",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -294,13 +294,13 @@
       }
     },
     "node_modules/@electron-forge/maker-wix": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-wix/-/maker-wix-6.0.4.tgz",
-      "integrity": "sha512-ro2VBZ4BaFJQDp1ByU1aHe7wQU4++VHBLihxjJMx0M5GP8eClbFPJah+KyiE5qz+eNVTg9FXCRcHiMUz0+Qffg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-wix/-/maker-wix-6.0.5.tgz",
+      "integrity": "sha512-c22srs2DdYdbrwQUeYyDfZ+r+Gf5jUBPQ03Rzr14kOWzvnS6zFfeFf0rhKOmLJ+sDyGlJXyYMjhN1w1VETiYsg==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/maker-base": "^6.0.4",
-        "@electron-forge/shared-types": "^6.0.4",
+        "@electron-forge/maker-base": "6.0.5",
+        "@electron-forge/shared-types": "6.0.5",
         "chalk": "^4.0.0",
         "electron-wix-msi": "^5.0.0",
         "log-symbols": "^4.0.0",
@@ -311,13 +311,13 @@
       }
     },
     "node_modules/@electron-forge/maker-zip": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-6.0.4.tgz",
-      "integrity": "sha512-tjBi46qU4vKpYUNUIv5ar6hBDjr9G7+QIUiaOj4UIN3Rwa20EvsYMBoMJBxV/CUUwkQc1NBihUPLco7PAVNb+g==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-6.0.5.tgz",
+      "integrity": "sha512-Yg256nGQUWT35EZyRIALpgtdM8WSvgZc0O4aA6Wy0S6ektaxyM2a+tO2ug/Vl+RgYA6oIeAADfkU2RxLiGnhbA==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/maker-base": "^6.0.4",
-        "@electron-forge/shared-types": "^6.0.4",
+        "@electron-forge/maker-base": "6.0.5",
+        "@electron-forge/shared-types": "6.0.5",
         "cross-zip": "^4.0.0",
         "fs-extra": "^10.0.0"
       },
@@ -326,37 +326,37 @@
       }
     },
     "node_modules/@electron-forge/plugin-base": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-6.0.4.tgz",
-      "integrity": "sha512-iILzbFzmUIGggsTNL9PO1ma6e4OuuhKunNnOkpkoyg6jIaz8Oh1WSHhOALMztlBn2FhreabZnBRy7JsvHVDXlg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-6.0.5.tgz",
+      "integrity": "sha512-Q2ywNq6Qzb9K1W59qzbJvI+NZaDPrHz7iq9W8UfyHoEDYLJsD368PzHtNaQFJx+ofZNgsSpukXoL9mGvN1lVbA==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "^6.0.4"
+        "@electron-forge/shared-types": "6.0.5"
       },
       "engines": {
         "node": ">= 14.17.5"
       }
     },
     "node_modules/@electron-forge/publisher-base": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-6.0.4.tgz",
-      "integrity": "sha512-0C86jnOSTo0z/W58zRx6BijuR4lscB0F6yXaBCFA5xaJ8+fVIsgz29kmVlLrp+YFRgatDCljvk+1+qVRM/Mfpg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-6.0.5.tgz",
+      "integrity": "sha512-gwOaMC3RKPO1mq3dqP9ko8kJptO41XU+I+pM66W/wvCNIQzisFCqrsx3d8A9RWsMJug0I1xNsYdBt99j1/2haA==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "^6.0.4"
+        "@electron-forge/shared-types": "6.0.5"
       },
       "engines": {
         "node": ">= 14.17.5"
       }
     },
     "node_modules/@electron-forge/publisher-github": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-github/-/publisher-github-6.0.4.tgz",
-      "integrity": "sha512-VFElA3dnXsjCledOuQQZnslhvYZEOHi+N86GzCGSirUNHpMHTop8Ktp54cbfrJD+wNn42b0PGP5EvhbLYkS9PA==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-github/-/publisher-github-6.0.5.tgz",
+      "integrity": "sha512-jrIkOTfIGiqTpu+IF7zBNIbOXrQQFp3cgoT/NEHKIjSsMznw+lMbQEEV7ue3G8OXtKeADbH23Jl3CzJeyLWxag==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/publisher-base": "^6.0.4",
-        "@electron-forge/shared-types": "^6.0.4",
+        "@electron-forge/publisher-base": "6.0.5",
+        "@electron-forge/shared-types": "6.0.5",
         "@octokit/core": "^3.2.4",
         "@octokit/plugin-retry": "^3.0.9",
         "@octokit/rest": "^18.0.11",
@@ -370,9 +370,9 @@
       }
     },
     "node_modules/@electron-forge/shared-types": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.0.4.tgz",
-      "integrity": "sha512-lILLKcGZqfJYVI1x6RssVh37E934rCOaSdBQ9I7LypdfI2NWL+5PLLoUqvXbok1V28m3/O5JrXdigwEIZdhjzQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-6.0.5.tgz",
+      "integrity": "sha512-FrJI11afw/Cxk0JwgWyKg9aPoHOdmMi4JHTY6pnmi95MjarQ1d0SIqKJUzX7q2lXPUAxqPKA2Wmykg6F2CThlg==",
       "dev": true,
       "dependencies": {
         "@electron/rebuild": "^3.2.10",
@@ -384,12 +384,12 @@
       }
     },
     "node_modules/@electron-forge/template-base": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-6.0.4.tgz",
-      "integrity": "sha512-23/b0n+ls0+c2+OG1XrHROk6i3PseONLJY3tcR42uFaP/yGZL8nJfgXE2qTKBwUyFQ0tCgUAD3a4vYkMPLKrwg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-6.0.5.tgz",
+      "integrity": "sha512-/3nOKPltnL8nVdZS2EpnKx1VMBqgLjW8TLRt8vtc+WdHtCVJBiU1Pt0JxTYDM3Raq/CclWGqVFb1svqorAon7Q==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "^6.0.4",
+        "@electron-forge/shared-types": "6.0.5",
         "@malept/cross-spawn-promise": "^2.0.0",
         "debug": "^4.3.1",
         "fs-extra": "^10.0.0",
@@ -400,13 +400,13 @@
       }
     },
     "node_modules/@electron-forge/template-webpack": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-6.0.4.tgz",
-      "integrity": "sha512-mrzNzkhsLfD20y/vfTYVBFSkptmgSEwqn4zh4vnzP9tzAJ4eMbvhfVtkK/XQfm8ZspPjs+RZSzRrRNo+e0iEaw==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-6.0.5.tgz",
+      "integrity": "sha512-fDINYYCJ3D8rMYgS5tTHhgC8d73pRpQKtyBCQFC9KkfdNMYJr9MPZeep5pYQqrOMjSgBpgaYSBL9Unsa5I1F2g==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "^6.0.4",
-        "@electron-forge/template-base": "^6.0.4",
+        "@electron-forge/shared-types": "6.0.5",
+        "@electron-forge/template-base": "6.0.5",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -414,13 +414,13 @@
       }
     },
     "node_modules/@electron-forge/template-webpack-typescript": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-6.0.4.tgz",
-      "integrity": "sha512-Z9fJ0JfZw9w5OVZgy0qVGapGMQqfaLyQSHzEfm2HQdGGJrHkeXJkMn8Yd1E8h5EPMb3jF5tHRw3VopelzcPQxQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-6.0.5.tgz",
+      "integrity": "sha512-YjKVszYRT4S3Sw3AOEpJokU7KPpmr0HWuO14+WHMO0FhQ1gaTMfPoz6QRHg0F1Ulz73mm6b3MLb9ID5igZv7Mw==",
       "dev": true,
       "dependencies": {
-        "@electron-forge/shared-types": "^6.0.4",
-        "@electron-forge/template-base": "^6.0.4",
+        "@electron-forge/shared-types": "6.0.5",
+        "@electron-forge/template-base": "6.0.5",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -428,9 +428,9 @@
       }
     },
     "node_modules/@electron/asar": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.2.tgz",
-      "integrity": "sha512-32fMU68x8a6zvxtC1IC/BhPDKTh8rQjdmwEplj3CDpnkcwBzZVN9v/8cK0LJqQ0FOQQVZW8BWZ1S6UU53TYR4w==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.3.tgz",
+      "integrity": "sha512-wmOfE6szYyqZhRIiLH+eyZEp+bGcJI0OD/SCvSUrfBE0jvauyGYO2ZhpWxmNCcDojKu5DYrsVqT5BOCZZ01XIg==",
       "dev": true,
       "dependencies": {
         "chromium-pickle-js": "^0.2.0",
@@ -681,9 +681,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-      "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
+      "integrity": "sha512-fluIaaV+GyV24CCu/ggiHdV+j4RNh85yQnAYS/G2mZODZgGmmlrgCydjUcV3YvxCm9x8nMAfThsqTni4KiXT4A==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -721,10 +721,19 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@eslint/js": {
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
+      "integrity": "sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@fontsource/fira-code": {
-      "version": "4.5.12",
-      "resolved": "https://registry.npmjs.org/@fontsource/fira-code/-/fira-code-4.5.12.tgz",
-      "integrity": "sha512-dAVGsgiVR6jslpuXosHH4/Jf8bsAIKL1RWqjVq4WpmxL7CFHfg9hT5bAv/Y3xsEj8kDTibEgpuC3eMfr9kb02g=="
+      "version": "4.5.13",
+      "resolved": "https://registry.npmjs.org/@fontsource/fira-code/-/fira-code-4.5.13.tgz",
+      "integrity": "sha512-T1IG6/2AXSwEKwlrEm3kyIL3RQTMblPyj68HgnBGl0IBGFxgS5LZ7StRdDo/QimJ4Tz6FQGHuy1Y/ShNxaUefA=="
     },
     "node_modules/@fontsource/roboto": {
       "version": "4.5.8",
@@ -1128,12 +1137,13 @@
       }
     },
     "node_modules/@reforged/maker-appimage": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@reforged/maker-appimage/-/maker-appimage-3.1.4.tgz",
-      "integrity": "sha512-HYOSzYoAXrF/OR67YLMFz5ODff09gwzLiqrwV+CD6FAGEuuiy0qS3JXeG5j3T9XNeC6oWQ9JgxCR3tNNLVfRSw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@reforged/maker-appimage/-/maker-appimage-3.1.8.tgz",
+      "integrity": "sha512-3Ih8BXWEKGdLEZgCQ3JF0hRVRjydZEkKsfETMwO8Th021wiJJL8MzRBiXQjV3AGN7XsQ5pr5QgUXZ7poGUoyyA==",
       "dev": true,
       "dependencies": {
         "@electron-forge/maker-base": "^6.0.4",
+        "@spacingbat3/lss": "^1.0.0",
         "node-fetch": "^3.2.5"
       },
       "engines": {
@@ -1189,6 +1199,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@spacingbat3/kolor/-/kolor-3.0.2.tgz",
       "integrity": "sha512-pkcCPLtYB+hmT/caxHB3VLw6/GlAnx0pK4qOZXtQYliJMWOXtjevDUMJfSHbBs/X4A6KaAjoNB+sRw6rdQXGeA=="
+    },
+    "node_modules/@spacingbat3/lss": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@spacingbat3/lss/-/lss-1.1.0.tgz",
+      "integrity": "sha512-obtFBmCIeDf+uWZhBLqPYOpCGeJRkNS6bwnzja/MNObRW0sT3TpSXpSzRlKvumrpuqUBZDC/pSipLdMSrjlaZw==",
+      "dev": true
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -1300,9 +1316,9 @@
       "optional": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+      "version": "18.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
       "dev": true
     },
     "node_modules/@types/pkgjs__parseargs": {
@@ -1342,9 +1358,9 @@
       "dev": true
     },
     "node_modules/@types/trusted-types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
-      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
+      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -1367,15 +1383,16 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.47.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.47.1.tgz",
-      "integrity": "sha512-r4RZ2Jl9kcQN7K/dcOT+J7NAimbiis4sSM9spvWimsBvDegMhKLA5vri2jG19PmIPbDjPeWzfUPQ2hjEzA4Nmg==",
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.54.0.tgz",
+      "integrity": "sha512-+hSN9BdSr629RF02d7mMtXhAJvDTyCbprNYJKrXETlul/Aml6YZwd90XioVbjejQeHbb3R8Dg0CkRgoJDxo8aw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.47.1",
-        "@typescript-eslint/type-utils": "5.47.1",
-        "@typescript-eslint/utils": "5.47.1",
+        "@typescript-eslint/scope-manager": "5.54.0",
+        "@typescript-eslint/type-utils": "5.54.0",
+        "@typescript-eslint/utils": "5.54.0",
         "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
         "regexpp": "^3.2.0",
@@ -1400,14 +1417,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.47.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.47.1.tgz",
-      "integrity": "sha512-9Vb+KIv29r6GPu4EboWOnQM7T+UjpjXvjCPhNORlgm40a9Ia9bvaPJswvtae1gip2QEeVeGh6YquqAzEgoRAlw==",
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.54.0.tgz",
+      "integrity": "sha512-aAVL3Mu2qTi+h/r04WI/5PfNWvO6pdhpeMRWk9R7rEV4mwJNzoWf5CCU5vDKBsPIFQFjEq1xg7XBI2rjiMXQbQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.47.1",
-        "@typescript-eslint/types": "5.47.1",
-        "@typescript-eslint/typescript-estree": "5.47.1",
+        "@typescript-eslint/scope-manager": "5.54.0",
+        "@typescript-eslint/types": "5.54.0",
+        "@typescript-eslint/typescript-estree": "5.54.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1427,13 +1444,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.47.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.47.1.tgz",
-      "integrity": "sha512-9hsFDsgUwrdOoW1D97Ewog7DYSHaq4WKuNs0LHF9RiCmqB0Z+XRR4Pf7u7u9z/8CciHuJ6yxNws1XznI3ddjEw==",
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.0.tgz",
+      "integrity": "sha512-VTPYNZ7vaWtYna9M4oD42zENOBrb+ZYyCNdFs949GcN8Miwn37b8b7eMj+EZaq7VK9fx0Jd+JhmkhjFhvnovhg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.47.1",
-        "@typescript-eslint/visitor-keys": "5.47.1"
+        "@typescript-eslint/types": "5.54.0",
+        "@typescript-eslint/visitor-keys": "5.54.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1444,13 +1461,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.47.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.47.1.tgz",
-      "integrity": "sha512-/UKOeo8ee80A7/GJA427oIrBi/Gd4osk/3auBUg4Rn9EahFpevVV1mUK8hjyQD5lHPqX397x6CwOk5WGh1E/1w==",
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.54.0.tgz",
+      "integrity": "sha512-WI+WMJ8+oS+LyflqsD4nlXMsVdzTMYTxl16myXPaCXnSgc7LWwMsjxQFZCK/rVmTZ3FN71Ct78ehO9bRC7erYQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.47.1",
-        "@typescript-eslint/utils": "5.47.1",
+        "@typescript-eslint/typescript-estree": "5.54.0",
+        "@typescript-eslint/utils": "5.54.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -1471,9 +1488,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.47.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.47.1.tgz",
-      "integrity": "sha512-CmALY9YWXEpwuu6377ybJBZdtSAnzXLSQcxLSqSQSbC7VfpMu/HLVdrnVJj7ycI138EHqocW02LPJErE35cE9A==",
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.0.tgz",
+      "integrity": "sha512-nExy+fDCBEgqblasfeE3aQ3NuafBUxZxgxXcYfzYRZFHdVvk5q60KhCSkG0noHgHRo/xQ/BOzURLZAafFpTkmQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1484,13 +1501,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.47.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.47.1.tgz",
-      "integrity": "sha512-4+ZhFSuISAvRi2xUszEj0xXbNTHceV9GbH9S8oAD2a/F9SW57aJNQVOCxG8GPfSWH/X4eOPdMEU2jYVuWKEpWA==",
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.0.tgz",
+      "integrity": "sha512-X2rJG97Wj/VRo5YxJ8Qx26Zqf0RRKsVHd4sav8NElhbZzhpBI8jU54i6hfo9eheumj4oO4dcRN1B/zIVEqR/MQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.47.1",
-        "@typescript-eslint/visitor-keys": "5.47.1",
+        "@typescript-eslint/types": "5.54.0",
+        "@typescript-eslint/visitor-keys": "5.54.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1511,16 +1528,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.47.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.47.1.tgz",
-      "integrity": "sha512-l90SdwqfmkuIVaREZ2ykEfCezepCLxzWMo5gVfcJsJCaT4jHT+QjgSkYhs5BMQmWqE9k3AtIfk4g211z/sTMVw==",
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.54.0.tgz",
+      "integrity": "sha512-cuwm8D/Z/7AuyAeJ+T0r4WZmlnlxQ8wt7C7fLpFlKMR+dY6QO79Cq1WpJhvZbMA4ZeZGHiRWnht7ZJ8qkdAunw==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.47.1",
-        "@typescript-eslint/types": "5.47.1",
-        "@typescript-eslint/typescript-estree": "5.47.1",
+        "@typescript-eslint/scope-manager": "5.54.0",
+        "@typescript-eslint/types": "5.54.0",
+        "@typescript-eslint/typescript-estree": "5.54.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -1537,12 +1554,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.47.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.47.1.tgz",
-      "integrity": "sha512-rF3pmut2JCCjh6BLRhNKdYjULMb1brvoaiWDlHfLNVgmnZ0sBVJrs3SyaKE1XoDDnJuAx/hDQryHYmPUuNq0ig==",
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.0.tgz",
+      "integrity": "sha512-xu4wT7aRCakGINTLGeyGqDn+78BwFlggwBjnHa1ar/KaGagnmwLYmlrXIrgAaQ3AE1Vd6nLfKASm7LrFHNbKGA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.47.1",
+        "@typescript-eslint/types": "5.54.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1560,9 +1577,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1687,9 +1704,9 @@
       }
     },
     "node_modules/appdmg": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.6.4.tgz",
-      "integrity": "sha512-YTilgNF0DF2DSRzGzzGDxaTMLXlhe3b3HB8RAaoJJ/VJXZbOlzIAcZ7gdPniHUVUuHjGwnS7fUMd4FvO2Rp94A==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.6.6.tgz",
+      "integrity": "sha512-GRmFKlCG+PWbcYF4LUNonTYmy0GjguDy6Jh9WP8mpd0T6j80XIJyXBiWlD0U+MLNhqV9Nhx49Gl9GpVToulpLg==",
       "dev": true,
       "optional": true,
       "os": [
@@ -1790,6 +1807,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz",
+      "integrity": "sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/asar": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/asar/-/asar-3.2.0.tgz",
@@ -1855,6 +1890,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/balanced-match": {
@@ -2050,9 +2097,9 @@
       }
     },
     "node_modules/cacache/node_modules/glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -2069,9 +2116,9 @@
       }
     },
     "node_modules/cacache/node_modules/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -2416,9 +2463,9 @@
       }
     },
     "node_modules/data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "dev": true,
       "engines": {
         "node": ">= 12"
@@ -2485,9 +2532,9 @@
       "dev": true
     },
     "node_modules/deepmerge-ts": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-4.2.2.tgz",
-      "integrity": "sha512-Ka3Kb21tiWjvQvS9U+1Dx+aqFAHsdTnMdYptLTmC2VAmDFMugWMY1e15aTODstipmCun8iNuqeSfcx6rsUUk0Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-4.3.0.tgz",
+      "integrity": "sha512-if3ZYdkD2dClhnXR5reKtG98cwyaRT1NeugQoAPTTfsOpV9kqyeiBF9Qa5RHjemb3KzD5ulqygv6ED3t5j9eJw==",
       "engines": {
         "node": ">=12.4.0"
       }
@@ -2523,9 +2570,9 @@
       }
     },
     "node_modules/define-properties": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
       "dev": true,
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
@@ -2610,9 +2657,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.1.tgz",
-      "integrity": "sha512-ewwFzHzrrneRjxzmK6oVz/rZn9VWspGFRDb4/rRtIsM1n36t9AKma/ye8syCpcw+XJ25kOK/hOG7t1j2I2yBqA=="
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.5.tgz",
+      "integrity": "sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA=="
     },
     "node_modules/ds-store": {
       "version": "0.1.6",
@@ -2627,9 +2674,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-22.0.0.tgz",
-      "integrity": "sha512-cgRc4wjyM+81A0E8UGv1HNJjL1HBI5cWNh/DUIjzYvoUuiEM0SS0hAH/zaFQ18xOz2ced6Yih8SybpOiOYJhdg==",
+      "version": "23.1.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-23.1.2.tgz",
+      "integrity": "sha512-ajE6xzIwH7swf8TlTU5WklDqpI3mPj4Am6690YrpCXzcp+E+dmMBXIajUUNt4joDrFhJC/lC6ZqDS2Q1BApKgQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2935,9 +2982,9 @@
       }
     },
     "node_modules/electron-installer-redhat": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/electron-installer-redhat/-/electron-installer-redhat-3.3.0.tgz",
-      "integrity": "sha512-hXIXB3uQXmXZy/v3MpbwWN4Of28ALpPt9ZyUDNEoSe0w7QZceL9IqI2K6Q6imiBJCLRC0hmT94WhlKj1RyGOWg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/electron-installer-redhat/-/electron-installer-redhat-3.4.0.tgz",
+      "integrity": "sha512-gEISr3U32Sgtj+fjxUAlSDo3wyGGq6OBx7rF5UdpIgbnpUvMN4W5uYb0ThpnAZ42VEJh/3aODQXHbFS4f5J3Iw==",
       "dev": true,
       "optional": true,
       "os": [
@@ -3260,9 +3307,9 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "16.18.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
-      "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
+      "version": "16.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.14.tgz",
+      "integrity": "sha512-wvzClDGQXOCVNU4APPopC2KtMYukaF1MN/W3xAmslx22Z4/IF1/izDMekuyoUlwfnDHYCIZGaj7jMwnJKBTxKw==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -3333,27 +3380,33 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
-      "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
+      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
       "dev": true,
       "dependencies": {
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.3",
         "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
+        "internal-slot": "^1.0.4",
+        "is-array-buffer": "^3.0.1",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.12.2",
         "object-keys": "^1.1.1",
@@ -3362,13 +3415,29 @@
         "safe-regex-test": "^1.0.0",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
-        "unbox-primitive": "^1.0.2"
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-shim-unscopables": {
@@ -3426,12 +3495,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.31.0.tgz",
-      "integrity": "sha512-0tQQEVdmPZ1UtUKXjX7EMm9BlgJ08G90IhWh0PKDCb3ZLsgAOHI8fYSIzYVZej92zsgq+ft0FGsxhJ3xo2tbuA==",
+      "version": "8.35.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.35.0.tgz",
+      "integrity": "sha512-BxAf1fVL7w+JLRQhWl2pzGeSiGqbWumV4WNvc9Rhp6tiCtm4oHnyPBSEtMGZwrQgudFQ+otqzWoPB7x+hxoWsw==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.4.1",
+        "@eslint/eslintrc": "^2.0.0",
+        "@eslint/js": "8.35.0",
         "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -3445,7 +3515,7 @@
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
         "espree": "^9.4.0",
-        "esquery": "^1.4.0",
+        "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
@@ -3482,13 +3552,14 @@
       }
     },
     "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
+      "integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
       "dev": true,
       "dependencies": {
         "debug": "^3.2.7",
-        "resolve": "^1.20.0"
+        "is-core-module": "^2.11.0",
+        "resolve": "^1.22.1"
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -3501,9 +3572,9 @@
       }
     },
     "node_modules/eslint-import-resolver-typescript": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.2.tgz",
-      "integrity": "sha512-zX4ebnnyXiykjhcBvKIf5TNvt8K7yX6bllTRZ14MiurKPjDpCAZujlszTdB8pcNXhZcOf+god4s9SjQa5GnytQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.3.tgz",
+      "integrity": "sha512-njRcKYBc3isE42LaTcJNVANR3R99H9bAxBDMNDr2W7yq5gYPxbU3MkdhsQukxZ/Xg9C2vcyLlDsbKfRDg0QvCQ==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
@@ -3583,23 +3654,25 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
-      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
+      "version": "2.27.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
+      "integrity": "sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.4",
-        "array.prototype.flat": "^1.2.5",
-        "debug": "^2.6.9",
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "array.prototype.flatmap": "^1.3.1",
+        "debug": "^3.2.7",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-module-utils": "^2.7.3",
+        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-module-utils": "^2.7.4",
         "has": "^1.0.3",
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.11.0",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
-        "object.values": "^1.1.5",
-        "resolve": "^1.22.0",
+        "object.values": "^1.1.6",
+        "resolve": "^1.22.1",
+        "semver": "^6.3.0",
         "tsconfig-paths": "^3.14.1"
       },
       "engines": {
@@ -3610,12 +3683,12 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/doctrine": {
@@ -3630,11 +3703,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eslint-plugin-import/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
     },
     "node_modules/eslint-plugin-json-schema-validator": {
       "version": "4.0.3",
@@ -3664,9 +3740,9 @@
       }
     },
     "node_modules/eslint-plugin-json-schema-validator/node_modules/ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -3695,9 +3771,9 @@
       "dev": true
     },
     "node_modules/eslint-plugin-json-schema-validator/node_modules/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -3827,9 +3903,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -4065,9 +4141,9 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
-      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4243,6 +4319,15 @@
       "optional": true,
       "dependencies": {
         "imul": "^1.0.0"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -4474,9 +4559,9 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -4546,9 +4631,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.3.0.tgz",
-      "integrity": "sha512-YCcF28IqSay3fqpIu5y3Krg/utCBHBeoflkZyHj/QcqI2nrLPC3ZegS9CmIo+hJb8K7aiGsuUl7PwWVjNG2HQQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.4.0.tgz",
+      "integrity": "sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
@@ -4647,9 +4732,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.19.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
-      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -4666,7 +4751,6 @@
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
       "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "define-properties": "^1.1.3"
       },
@@ -4800,6 +4884,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
@@ -4860,9 +4956,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "node_modules/http-proxy-agent": {
@@ -4915,9 +5011,9 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
-      "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true,
       "bin": {
         "husky": "lib/bin.js"
@@ -5055,12 +5151,12 @@
       "dev": true
     },
     "node_modules/internal-slot": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.4.tgz",
-      "integrity": "sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       },
@@ -5082,6 +5178,20 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
       "dev": true
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -5365,6 +5475,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -5429,9 +5558,9 @@
       "dev": true
     },
     "node_modules/js-sdsl": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
-      "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -5468,9 +5597,9 @@
       }
     },
     "node_modules/json-schema-migrate/node_modules/ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -5601,9 +5730,9 @@
       }
     },
     "node_modules/listr2": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.6.tgz",
-      "integrity": "sha512-u60KxKBy1BR2uLJNTWNptzWQ1ob/gjMzIJPZffAENzpZqbMZ/5PrXXOomDcevIS/+IB7s1mmCEtSlT2qHWMqag==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.7.tgz",
+      "integrity": "sha512-MD+qXHPmtivrHIDRwPYdfNkrzqDiuaKU/rfBcec3WMyMF3xylQj3jMq344OtvQxz7zaCFViRAeqlr2AFhPvXHw==",
       "dev": true,
       "dependencies": {
         "cli-truncate": "^2.1.0",
@@ -5611,7 +5740,7 @@
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
         "rfdc": "^1.3.0",
-        "rxjs": "^7.5.7",
+        "rxjs": "^7.8.0",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       },
@@ -5778,9 +5907,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.1.tgz",
+      "integrity": "sha512-8/HcIENyQnfUTCDizRu9rrDyG6XG/21M4X7/YEGZeD76ZJilFPAUVb/2zysFf7VVO1LEjCDFyHp8pMMvozIrvg==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -5858,9 +5987,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
-      "integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -5969,9 +6098,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6132,9 +6261,9 @@
       "dev": true
     },
     "node_modules/node-abi": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.30.0.tgz",
-      "integrity": "sha512-qWO5l3SCqbwQavymOmtTVuCWZE23++S+rxyoHjXqUmPyzRcaoI4lA2gO55/drddGnedAyjA7sk76SfQ5lfUMnw==",
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.33.0.tgz",
+      "integrity": "sha512-7GGVawqyHF4pfd0YFybhv/eM9JwTtPqx0mAanQ146O3FlSh3pA24zf9IRQTOsfTSqXTNzPSP5iagAJ94jjuVog==",
       "dev": true,
       "dependencies": {
         "semver": "^7.3.5"
@@ -6178,9 +6307,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -6222,9 +6351,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
       "dev": true,
       "bin": {
         "node-gyp-build": "bin.js",
@@ -6317,9 +6446,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6394,9 +6523,9 @@
       }
     },
     "node_modules/open": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
@@ -6802,9 +6931,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -6978,9 +7107,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
       "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -7687,13 +7816,13 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.4.tgz",
-      "integrity": "sha512-Dn2ZkzMdSX827QbowGbU/4yjWuvNaCoScLLoMo/yKbu+P4GBR6cRGKZH27k6a9bRzdqcyd1DE96pQtQ6uNkmyw==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+      "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
       "dev": true,
       "dependencies": {
         "@pkgr/utils": "^2.3.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -7729,13 +7858,10 @@
       }
     },
     "node_modules/tar/node_modules/minipass": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
-      "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.4.tgz",
+      "integrity": "sha512-lwycX3cBMTvcejsHITUgYj6Gy6A7Nh4Q6h9NP4sTHY1ccJlC7yKzDmiShEHsJ16Jf1nKGDEaiHxiltsJEvk0nQ==",
       "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
       "engines": {
         "node": ">=8"
       }
@@ -7907,21 +8033,21 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
+      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -7985,10 +8111,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8181,6 +8321,26 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -8223,15 +8383,15 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+      "integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -8302,9 +8462,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/ws": "^8.5.1",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",
-    "electron": ">=17.0.0 <23.0.0",
+    "electron": ">=23.0.0",
     "eslint": "latest",
     "eslint-import-resolver-typescript": "latest",
     "eslint-plugin-import": "latest",


### PR DESCRIPTION
Updates electron to at least v23.0.0.

This is intended to fix the [issue](https://github.com/SpacingBat3/WebCord/issues/279) encountered on long-running VCs, where the whole thing freezes without warning and you're left talking to yourself (not like that ever happened to me).

Most notable breaking change is that Windows 8.1 and below are no longer supported. https://releases.electronjs.org/release/v23.0.0

