### PR TITLE
Enable ⌘A shortcut to select text on macOS (fix issue #319)

### DIFF
--- a/sources/code/main/modules/menu.ts
+++ b/sources/code/main/modules/menu.ts
@@ -225,7 +225,9 @@ export function bar(repoLink: string, parent: Electron.BrowserWindow): Electron.
       { type: "separator" },
       { label: strings.context.cut, role: "cut" },
       { label: strings.context.copy, role: "copy" },
-      { label: strings.context.paste, role: "paste" }
+      { label: strings.context.paste, role: "paste" },
+      { type: "separator" },
+      { role: "selectAll" },
     ]},
     // View
     {


### PR DESCRIPTION
Howdy, just figured I'd re-open this PR (rebased copy of #373) in case you're doing more minor patches on the v4 branch. I want to use WebCord as my primary Discord client, but I can't without this bug being fixed.

- Makes "Select All" appear in the "Edit" menu.
- In macOS, this must be present for the ⌘A shortcut to work.
- Fixes issue #319