### PR TITLE
Change Fosscord to Spacebar

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -40,7 +40,7 @@
 [![Weblate badge][l10nbadge]][l10n] [![GitHub downloads][dlbadge]][downloads]
 [![Discord server][discord-badge]][discord-url]
 
-A Discord and [Fosscord] client implemented directly without [Discord API][discordapi].
+A Discord and [Spacebar] client implemented directly without [Discord API][discordapi].
 Made in 🇵🇱 with the [Electron][electron] framework.
 
 </div>
@@ -208,7 +208,7 @@ you don't even need to be familiar with programming at all!
 [electron]: https://www.electronjs.org/ "Build cross-platform desktop apps with JavaScript, HTML, and CSS."
 [electron-forge]: https://www.electronforge.io/ "A complete tool for creating, publishing, and installing modern Electron applications."
 [license]: ../LICENSE "WebCord license"
-[Fosscord]: https://fosscord.com "Free, open source and selfhostable Discord compatible chat, voice and video platform."
+[Spacebar]: https://spacebar.chat "Free, open source and selfhostable Discord compatible chat, voice and video platform."
 [discordapi]: https://discord.com/developers/docs/reference "Official Discord REST API documentation"
 [chromiumbounty]: https://bughunters.google.com/about/rules/5745167867576320/chrome-vulnerability-reward-program-rules "Chrome Vulnerability Reward Program Rules"
 [Electron#Security]: https://www.electronjs.org/docs/latest/tutorial/security "Security | Electron Documentation"


### PR DESCRIPTION
Fosscord has rebranded into Spacebar. This change updates the name in the Readme