### PR TITLE
Properly resolve relative paths in CSS imports

### DIFF
--- a/sources/code/main/modules/extensions.ts
+++ b/sources/code/main/modules/extensions.ts
@@ -27,8 +27,7 @@ async function parseImports(cssString: string, importCalls: string[], maxTries=5
   cssString.match(anyImport)?.forEach(singleImport => {
     const matches = /^@import (?:(?:url\()?["']?([^"';)]*)["']?)\)?;?/m.exec(singleImport);
     if(matches?.[0] === undefined || matches[1] === undefined) return;
-    const lastUrl = importCalls[importCalls.length - 1] ?? "";
-    const file = resolve(lastUrl, matches[1]);
+    const file = resolve(importCalls.at(-1) ?? "", matches[1]);
     if(importCalls.includes(file)) {
       promises.push(Promise.reject(new Error("Circular reference in CSS imports are disallowed: " + file)));
       return;

--- a/sources/code/main/modules/extensions.ts
+++ b/sources/code/main/modules/extensions.ts
@@ -1,4 +1,3 @@
-import { dirname } from "path";
 import { resolve } from "url";
 import { commonCatches } from "./error";
 
@@ -28,8 +27,8 @@ async function parseImports(cssString: string, importCalls: string[], maxTries=5
   cssString.match(anyImport)?.forEach(singleImport => {
     const matches = /^@import (?:(?:url\()?["']?([^"';)]*)["']?)\)?;?/m.exec(singleImport);
     if(matches?.[0] === undefined || matches[1] === undefined) return;
-    const lastDir = dirname(importCalls[importCalls.length - 1] ?? "") + "/";
-    const file = resolve(lastDir, matches[1]);
+    const lastUrl = importCalls[importCalls.length - 1] ?? "";
+    const file = resolve(lastUrl, matches[1]);
     if(importCalls.includes(file)) {
       promises.push(Promise.reject(new Error("Circular reference in CSS imports are disallowed: " + file)));
       return;


### PR DESCRIPTION
Currently, WebCord cannot resolve relative imports because it simply constructs a `new URL()` with the relative URL which will fail.

This change passes context about the current file to `parseImports` and `fetchOrRead` to prepend the previous URL's directory name if creating a URL fails.