### PR TITLE
Enable macOS traffic light controls in main window

### DIFF
--- a/sources/code/main/modules/config.ts
+++ b/sources/code/main/modules/config.ts
@@ -64,6 +64,9 @@ const defaultAppConfig = Object.freeze({
       window: {
         transparent: false,
         hideOnClose: true
+      },
+      darwin: {
+        csd: false
       }
     },
     privacy: {

--- a/sources/code/main/windows/main.ts
+++ b/sources/code/main/windows/main.ts
@@ -52,6 +52,10 @@ export default function createMainWindow(...flags:MainWindowFlags): BrowserWindo
     backgroundColor: appInfo.backgroundColor,
     transparent: appConfig.value.settings.general.window.transparent,
     show: false,
+    ...(process.platform === "darwin" && {
+      titleBarStyle: "hiddenInset",
+      trafficLightPosition: { x: 10, y: 10 },
+    }),
     webPreferences: {
       preload: resolve(app.getAppPath(), "app/code/renderer/preload/main.js"),
       nodeIntegration: false, // Never set to "true"!

--- a/sources/code/main/windows/main.ts
+++ b/sources/code/main/windows/main.ts
@@ -52,7 +52,7 @@ export default function createMainWindow(...flags:MainWindowFlags): BrowserWindo
     backgroundColor: appInfo.backgroundColor,
     transparent: appConfig.value.settings.general.window.transparent,
     show: false,
-    ...(process.platform === "darwin" && {
+    ...(process.platform === "darwin" && appConfig.value.settings.general.darwin.csd && {
       titleBarStyle: "hiddenInset",
       trafficLightPosition: { x: 10, y: 10 },
     }),

--- a/sources/translations/en/settings.json
+++ b/sources/translations/en/settings.json
@@ -30,6 +30,13 @@
                 "transparent": "Allow for translucent window background.",
                 "hideOnClose": "Hide window to tray with the close button."
             }
+        },
+        "darwin": {
+            "name": "macOS related settings",
+            "description": "Controls integrations with macOS system.",
+            "labels": {
+                "csd": "Enable client-side traffic lights placement."
+            }
         }
     },
     "privacy": {

--- a/sources/translations/pl/settings.json
+++ b/sources/translations/pl/settings.json
@@ -30,6 +30,13 @@
                 "transparent": "Zezwól na przezroczyste tło okna.",
                 "hideOnClose": "Ukrywaj okno do zasobnika przyciskiem zamykania."
             }
+        },
+        "darwin": {
+            "name": "Ustawienia dla systemu macOS",
+            "description": "Steruje integracją z systemem macOS.",
+            "labels": {
+                "csd": "Włącz pozycjonowanie sygnalizacji świetlnej po stronie klienta."
+            }
         }
     },
     "privacy": {


### PR DESCRIPTION
This PR enables native macOS traffic light controls (close/minimize/maximize) in the main Electron window. This improves usability and consistency with native macOS apps.

Tested on macOS 15.3.1 (Apple Silicon).

Before:

<img width="603" alt="Screenshot 2025-04-18 at 4 07 29 PM" src="https://github.com/user-attachments/assets/7fabb07b-547d-4db2-a779-666ac2e1aa30" />

After:

<img width="589" alt="Screenshot 2025-04-18 at 4 03 39 PM" src="https://github.com/user-attachments/assets/af7e6892-6f96-4f79-8e4e-c6204efdeebd" />
